### PR TITLE
Include ApproximateCreationDateTime in DDB Stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ NewImage,
 OldImage,
 SequenceNumber,
 SizeBytes,
+ApproximateCreationDateTime,
 eventName
 }
 ```

--- a/index.js
+++ b/index.js
@@ -139,6 +139,7 @@ function createDynamoDataItem(record) {
     // add the sequence number and other metadata
     output.SequenceNumber = record.dynamodb.SequenceNumber;
     output.SizeBytes = record.dynamodb.SizeBytes;
+    output.ApproximateCreationDateTime = record.dynamodb.ApproximateCreationDateTime;
     output.eventName = record.eventName;
 
     return output;


### PR DESCRIPTION
ApproximateCreationDateTime attribute should also be
carried to a condensed version of a dynamodb change
record.