### PR TITLE
Allow use as a module.

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,10 @@ var transform = require('./transformer');
  * own new function
  */
 var useTransformer = transform.jsonToStringTransformer.bind(undefined);
+function setTransformer(transformer) {
+    useTransformer = transformer
+}
+exports.setTransformer = setTransformer
 
 /*
  * Configure destination router. By default all records route to the configured
@@ -50,6 +54,10 @@ var router = require('./router');
  * default router
  */
 var useRouter = router.defaultRouting.bind(undefined);
+function setRouter(router) {
+    useRouter = router
+}
+exports.setRouter = setRouter
 // example for using routing based on messages attributes
 // var attributeMap = {
 // "binaryValue" : {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "lambda-stream-to-firehose",
 	"description": "An AWS Lambda function that forwards data from a Kinesis or DynamoDB Update Stream to a Kinesis Firehose Delivery Stream",
-	"version": "1.4.3",
+	"version": "1.4.4",
 	"dependencies": 
 	{
 		"async": "2.1.4",
@@ -22,5 +22,5 @@
 	"main": "index.js",
 	"license": "Apache-2.0",
 	"files": 
-	["index.js","lambda.json","tagKinesisStream.sh","package.json","README.md","LICENSE","NOTICE.txt"]
+	["constants.js","index.js","router.js","transformer.js","lambda.json","tagKinesisStream.sh","package.json","README.md","LICENSE","NOTICE.txt"]
 }


### PR DESCRIPTION
This is meant to allow use of it as a module so a wrapper can be written around it and keep the fork intact.

As someone wanting to use it as a module, you can just do:

import { setTransformer, setRouter, handler }

setTransformer(...your transformer logic...)
setRouter(...your router logic...)

index.handler = handler