### PR TITLE
updated to include the userIdentity attribute added by DynamoDB TTL

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,6 +141,8 @@ function createDynamoDataItem(record) {
     output.SizeBytes = record.dynamodb.SizeBytes;
     output.ApproximateCreationDateTime = record.dynamodb.ApproximateCreationDateTime;
     output.eventName = record.eventName;
+    // adding userIdentity, used by DynamoDB TTL to indicate removal by TTL as opposed to user initiated remove 
+    output.userIdentity = record.userIdentity;
 
     return output;
 }


### PR DESCRIPTION
Updated to include the new userIdentity attribute in the DynamoDB metadata of items in the stream. This attribute is added by DynamoDB TTL to indicate that the remove was done by TTL rather than a user initiated remove.