### PR TITLE
Added missing parameter to recursive verifyDeliveryStreamMapping call

### DIFF
--- a/index.js
+++ b/index.js
@@ -295,7 +295,7 @@ function verifyDeliveryStreamMapping(streamName, shouldFailbackToDefaultDelivery
 	if (err) {
 	    if (shouldFailbackToDefaultDeliveryStream) {
 		deliveryStreamMapping[streamName] = deliveryStreamMapping['DEFAULT'];
-		exports.verifyDeliveryStreamMapping(streamName, false, event, callback);
+		exports.verifyDeliveryStreamMapping(streamName, false, context, event, callback);
 	    } else {
 		exports.onCompletion(context, event, undefined, ERROR, "Could not find suitable delivery stream for " + streamName + " and the " + "default delivery stream ("
 			+ deliveryStreamMapping['DEFAULT'] + ") either doesn't exist or is disabled.");


### PR DESCRIPTION
I think this is just a bug/typo? Noticed it because it callback is was undefined in the recursive call which caused the function to crash.