### PR TITLE
Fixes a bug in the writable event types feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -480,8 +480,11 @@ function processEvent(event, serviceName, streamName, callback) {
                 }
                 var data = exports.createDynamoDataItem(record);
                 recordCallback(null, data);
-            } else if (debug) {
-                console.log("Skipping record: " + JSON.stringify(record) + " with event type: " + record.eventName + " when writable events are: " + writableEventTypes);
+            } else {
+                if (debug) {
+                    console.log("Skipping record: " + JSON.stringify(record) + " with event type: " + record.eventName + " when writable events are: " + writableEventTypes);
+                }
+                recordCallback(null, null);
             }
         }
     }, function (err, extractedUserRecords) {
@@ -490,7 +493,7 @@ function processEvent(event, serviceName, streamName, callback) {
         } else {
             // extractedUserRecords will be array[array[Object]], so
             // flatten to array[Object]
-            var userRecords = [].concat.apply([], extractedUserRecords);
+            var userRecords = [].concat.apply([], extractedUserRecords.filter(record => record !== null));
 
             // transform the user records
             transform.transformRecords(serviceName, useTransformer, userRecords, function (err, transformed) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "lambda-stream-to-firehose",
 	"description": "An AWS Lambda function that forwards data from a Kinesis or DynamoDB Update Stream to a Kinesis Firehose Delivery Stream",
-	"version": "1.5.2",
+	"version": "1.5.3",
 	"dependencies": 
 	{
 		"async": "2.1.4",


### PR DESCRIPTION
*Issue #, if available:* Continuation of #66

*Description of changes:* Bug patch + Releasing v1.5.3 to tag this functionality

Bug: 

In PR #67, we had added an if-else block in an async map-block wherein we should have returned something for each element in the map. Not returning a value for update/delete events (else block) makes the rest of the chain go into an inconsistent state without failing the lambda run.

```js
records.map(record => record.writable ? return record : console.log(“Skipping”)).writeToFirehose();
```

Patch:

In this PR, we're making the change to return null for non-writable event types, and filtering them out (nulls) in the chaining.

```js
records.map(record => record.writable ? return record : return null).filter(record => record !== null).writeToFirehose();
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
